### PR TITLE
feat: configure backend connection

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:5000/api
+REACT_APP_API_URL=https://greencard-backend.onrender.com/api

--- a/src/pages/IAFormMeilleurProduit.jsx
+++ b/src/pages/IAFormMeilleurProduit.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+const API_URL = process.env.REACT_APP_API_URL || 'https://greencard-backend.onrender.com/api';
 
 const categories = ["Produits laitiers", "Légumes", "Fruits", "Boulangerie"];
 

--- a/src/pages/IAFormPredictGoodSale.jsx
+++ b/src/pages/IAFormPredictGoodSale.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+const API_URL = process.env.REACT_APP_API_URL || 'https://greencard-backend.onrender.com/api';
 
 const categories = ["Produits laitiers", "Légumes", "Fruits", "Boulangerie"];
 const regions = ["Grand Est", "Nouvelle-Aquitaine", "Bourgogne-Franche-Comté", "Pays de la Loire", "Hauts-de-France", "Auvergne-Rhône-Alpes", "Occitanie", "Provence-Alpes-Côte d'Azur", "Normandie"];

--- a/src/pages/ProductList.jsx
+++ b/src/pages/ProductList.jsx
@@ -3,8 +3,8 @@ import axios from 'axios';
 import ProductCard from '../components/ProductCard';
 import ProducerProductForm from '../components/ProducerProductForm';
 
-// Définir l'URL de base de l'API
-const API_URL = 'https://greencard-backend.onrender.com/api';
+// Définir l'URL de base de l'API à partir des variables d'environnement
+const API_URL = process.env.REACT_APP_API_URL || 'https://greencard-backend.onrender.com/api';
 
 const ProductList = ({ onAddToCart, user }) => {
   const [items, setItems] = useState([]);


### PR DESCRIPTION
## Summary
- point API base URL to https://greencard-backend.onrender.com
- load API URL from env in product and AI forms

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b4c545360832f9cb2ef29e05496b8