### PR TITLE
fix: remove stray debug text on withdrawal form

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -370,7 +370,6 @@ const Dashboard = ({ user, setUser }) => {
                   {withdrawalMessage && <div style={{ color: '#22C55E', marginTop: 8 }}>{withdrawalMessage}</div>}
                 </div>
               )}
- { useState }
             </div>
             <div style={{
               background: "#fff",


### PR DESCRIPTION
## Summary
- remove leftover useState expression near withdrawal button to prevent import text rendering

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_689b7508d850832f82e0defd7f5143f8