### PR TITLE
Attach auth token to API requests

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -13,6 +13,23 @@ const http = axios.create({
   // timeout: 15000,
 });
 
+// Ajoute automatiquement le token d'authentification à chaque requête
+http.interceptors.request.use((config) => {
+  const stored = localStorage.getItem("greencart_user");
+  if (stored) {
+    try {
+      const token = JSON.parse(stored)?.token;
+      if (token) {
+        config.headers = config.headers || {};
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+    } catch {
+      // ignore JSON parse errors and continue without token
+    }
+  }
+  return config;
+});
+
 // --- Auth ---
 export const auth = {
   register: (data) => http.post("/auth/register", data),


### PR DESCRIPTION
## Summary
- add auth token interceptor to axios service to fix order placement error

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_689b78dd1df4832f86cffc8b1389ebb4