### PR TITLE
fix: prevent credentialed requests

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -12,7 +12,9 @@ const Footer = () => {
       const res = await fetch(`${API_URL}/newsletter/subscribe`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email })
+        body: JSON.stringify({ email }),
+        // Ne pas inclure de cookies sur le cross-origin
+        credentials: 'omit'
       });
       if (res.ok) {
         setMsg('Merci ! Vous êtes inscrit à la newsletter.');

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ import App from './App.jsx'; // <-- utilise App.jsx
 
 // Configure axios to use the deployed backend and attach auth tokens
 axios.defaults.baseURL = process.env.REACT_APP_API_URL || 'https://greencard-backend.onrender.com/api';
+// Ne jamais envoyer automatiquement des cookies afin d'éviter les erreurs CORS
+axios.defaults.withCredentials = false;
 axios.interceptors.request.use((config) => {
   const stored = localStorage.getItem('greencart_user');
   if (stored) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -10,6 +10,8 @@ export const API_URL =
 const http = axios.create({
   baseURL: API_URL,
   headers: { "Content-Type": "application/json" },
+  // Empêche l'envoi automatique des cookies sur les requêtes cross-origin
+  withCredentials: false,
   // timeout: 15000,
 });
 


### PR DESCRIPTION
## Summary
- avoid sending cookies on cross-origin requests
- document no-credential policy for axios
- omit newsletter cookies to prevent CORS errors

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_689c86fe5898832f9a255bc8b2e25d5d